### PR TITLE
Render vignettes using knitrBoostrap itself 

### DIFF
--- a/vignettes/Makefile
+++ b/vignettes/Makefile
@@ -1,0 +1,4 @@
+all:
+	"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "library('knitrBootstrap'); library('rmarkdown'); for(i in list.files(pattern='.Rmd')) render(i, bootstrap_document(theme.chooser = TRUE, highlight.chooser = TRUE))"
+clean:
+	rm -fr *_files


### PR DESCRIPTION
Using a Makefile inside the vignettes directory we can render the vignettes using knitrBootstrap itself. Thus when using

``` S
browseVignettes("knitrBootstrap")
```

the user will see the nice vignettes instead of the ones generated using knitr only.
