### PR TITLE
Added option to include custom header contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ two different types of options.
 - `bootstrap.theme` - (`Default`) - Set the default bootstrap style.
 - `bootstrap.highlight` - (`HighlightJS`) - Set the default code style.
 - `bootstrap.menu` - (`TRUE`) - Whether to include the bottom navbar.
+- `custom.header` - (`NULL`) - External HTML header contents to include in header block.
 - `clean_supporting` - (`TRUE`) - Clean the intermediate supporting documents. (this is only an option for the bootstap_document function)
 
 ### Chunk Options ###


### PR DESCRIPTION
Added a `custom.header` option to allow for custom JS/CSS, etc. to be included in the HTML header block.
