### PR TITLE
Add well class to TOC

### DIFF
--- a/inst/rmarkdown/templates/knitrBootstrap/skeleton/js/knitrBootstrap.js
+++ b/inst/rmarkdown/templates/knitrBootstrap/skeleton/js/knitrBootstrap.js
@@ -10,6 +10,9 @@ $(function() {
   var hidden_types = ['source']
   var output_types = ['output', 'message', 'warning', 'error']
 
+  /* add well class to toc */
+  $('#toc').addClass("well");
+  
   /* add nav class to ul in toc */
   $('#toc ul').each(function() {
     $(this).addClass("nav")

--- a/inst/rmarkdown/templates/simple/skeleton/js/simple.js
+++ b/inst/rmarkdown/templates/simple/skeleton/js/simple.js
@@ -2,6 +2,9 @@
 $(function() {
   "use strict";
 
+  /* add well class to toc */
+  $('#toc').addClass("well");
+  
   /* add nav class to ul in toc */
   $('#toc ul').each(function() {
     $(this).addClass("nav")


### PR DESCRIPTION
I added the well class to toc elements in both knitrBootstrap.js and simple.js to mimic behavior in previous versions.
![image](https://cloud.githubusercontent.com/assets/2127125/4636626/6ac659ca-53e4-11e4-96a2-d8e8dc7b7bb3.png)
