### PR TITLE
Support custom pandoc args

### DIFF
--- a/R/knit_bootstrap.R
+++ b/R/knit_bootstrap.R
@@ -52,11 +52,7 @@ simple_document <- function(css = NULL, theme = NULL, highlight = NULL, ...){
     template =
       system.file(
         package="knitrBootstrap", "rmarkdown/rmd/default.html"),
-        pandoc_args = c(
-                        "--no-wrap",
-                        "--variable",
-                        "mathjax-url:https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
-                        ),
+        pandoc_args = check_pandoc_args(pandoc_args),
         self_contained = FALSE, ...)
 
   results$knitr <- list(
@@ -68,7 +64,7 @@ simple_document <- function(css = NULL, theme = NULL, highlight = NULL, ...){
 }
 
 #" @export
-bootstrap_document <- function(css = NULL, theme = NULL, highlight = NULL, ...){
+bootstrap_document <- function(css = NULL, theme = NULL, highlight = NULL, pandoc_args, ...){
   theme <- theme %||% "default"
   highlight <- highlight %||% "default"
 
@@ -82,11 +78,7 @@ bootstrap_document <- function(css = NULL, theme = NULL, highlight = NULL, ...){
       html_dependency_knitrBootstrap()
      ),
     template=system.file(package="knitrBootstrap", "rmarkdown/rmd/default.html"),
-        pandoc_args = c(
-                        "--no-wrap",
-                        "--variable",
-                        "mathjax-url:https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
-                        ),
+        pandoc_args = check_pandoc_args(pandoc_args),
       self_contained=FALSE, ...)
 
   results$knitr <- list(

--- a/R/utils.R
+++ b/R/utils.R
@@ -41,7 +41,7 @@ check_pandoc_args <- function(args){
   if(!"--no-wrap" %in% args){
     args <- c(args, "--no-wrap")
   }
-  if(!grepl("mathjax-url:", args)){
+  if(!any(grepl("mathjax-url:", args))){
     args <- c(args, "--variable", "mathjax-url:https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML")
   }
   args

--- a/R/utils.R
+++ b/R/utils.R
@@ -36,3 +36,13 @@ print_attributes = function(attributes) {
                 FUN=generate_attribute, USE.NAMES=FALSE, attributes), collapse= ' ')
 
 }
+
+check_pandoc_args <- function(args){
+  if(!"--no-wrap" %in% args){
+    args <- c(args, "--no-wrap")
+  }
+  if(!grepl("mathjax-url:", args)){
+    args <- c(args, "--variable", "mathjax-url:https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML")
+  }
+  args
+}


### PR DESCRIPTION
This makes it possible to specify *pandoc_args* in the yaml front matter (as is possible with the *rmarkdown* document formats) to further customise the pandoc conversion process. I've added code to ensure that the current arguments  

    --no-wrap
and

    --variable mathjax-url:https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
are always added to the list if they aren't provided by the user. Note that as written currently a different mathjax url will be accepted. Not sure whether that is an issue (although it does provide more flexibility for those who would like to change some MathJAX options).