### PR TITLE
Added missing default value for pandoc_args

### DIFF
--- a/R/knit_bootstrap.R
+++ b/R/knit_bootstrap.R
@@ -35,9 +35,14 @@ button_types <- c("source" = "btn-primary",
                  "warning" = "btn-warning",
                  "error" = "btn-danger")
 #" @export
-simple_document <- function(css = NULL, theme = NULL, highlight = NULL, ...){
+simple_document <- function(css = NULL, theme = NULL, highlight = NULL, pandoc_args = NULL, ...){
   theme <- theme %||% "default"
   highlight <- highlight %||% "default"
+   pandoc_args <- pandoc_args %||% c(
+                        "--no-wrap",
+                        "--variable",
+                        "mathjax-url:https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
+                  )
 
   results <- rmarkdown::html_document(
     highlight = NULL,
@@ -64,9 +69,14 @@ simple_document <- function(css = NULL, theme = NULL, highlight = NULL, ...){
 }
 
 #" @export
-bootstrap_document <- function(css = NULL, theme = NULL, highlight = NULL, pandoc_args, ...){
+bootstrap_document <- function(css = NULL, theme = NULL, highlight = NULL, pandoc_args = NULL, ...){
   theme <- theme %||% "default"
   highlight <- highlight %||% "default"
+  pandoc_args <- pandoc_args %||% c(
+                        "--no-wrap",
+                        "--variable",
+                        "mathjax-url:https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
+                  )
 
   results <- rmarkdown::html_document(
     highlight = NULL,


### PR DESCRIPTION
The recently introduced `pandoc_args` option was missing from *simple_document* and missing a default value in *bootstrap_document*.
The issue was reported in a comment to #173.