### PR TITLE
Add tooltips to label chunks

### DIFF
--- a/R/knit_bootstrap.R
+++ b/R/knit_bootstrap.R
@@ -209,6 +209,7 @@ generate_panel <- function(engine, name, x, hide){
 generate_simple_panel <- function(engine, name, x, show){
   tags$div(class=c("panel", panel_types[name]),
            tags$button(class=c("btn", "btn-default", "btn-xs", button_types[name]),
+                       'data-toggle'="tooltip", title=paste(engine, name, collapse=" "),
                        tags$span(class=c("glyphicon", "glyphicon-chevron-left"))),
            tags$pre(tags$code(class=c(name, tolower(engine)), x))
            )

--- a/inst/rmarkdown/templates/simple/skeleton/js/simple.js
+++ b/inst/rmarkdown/templates/simple/skeleton/js/simple.js
@@ -38,5 +38,9 @@ $(function() {
         }
     });
   });
+  
+  /* Activate tooltips */
+  $('[data-toggle="tooltip"]').tooltip();
+
 
 });


### PR DESCRIPTION
I've added tooltips to the buttons used to toggle source (and other) chunks in *simple_document* format. As discussed in #68 these buttons are less noisy but also less informative. The solution suggested by @jimhester was to use tooltips for labelling of the chunks instead. This is a first pass at implementing this. 

One question is whether the tooltip should be associated with the button or the surrounding panel. My feeling is that having the tooltip pop up every time the mouse pointer enters one of the chunks might get a bit annoying. On the other hand, the buttons are relatively small and a user unfamiliar with the output produced by *knitrBootstrap* could go a long time without triggering a tooltip and that mostly defeats the purpose.