### PR TITLE
Support Rmarkdown's tabbed navigation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Depends:
     R (>= 3.0.0)
 Imports:
     knitr (>= 1.5.25),
-    rmarkdown,
+    rmarkdown (>= 0.9.5),
     markdown
 Suggests:
     testthat,

--- a/R/knit_bootstrap.R
+++ b/R/knit_bootstrap.R
@@ -52,6 +52,7 @@ simple_document <- function(css = NULL, theme = NULL, highlight = NULL, pandoc_a
       html_dependency_bootstrap3(theme),
       html_dependency_hljs(highlight),
       html_dependency_magnific_popup(),
+      html_dependency_navigation(),
       html_dependency_simple()
       ),
     template =
@@ -85,6 +86,7 @@ bootstrap_document <- function(css = NULL, theme = NULL, highlight = NULL, pando
       html_dependency_bootstrap3(theme),
       html_dependency_hljs(highlight),
       html_dependency_magnific_popup(),
+      html_dependency_navigation(),
       html_dependency_knitrBootstrap()
      ),
     template=system.file(package="knitrBootstrap", "rmarkdown/rmd/default.html"),
@@ -141,6 +143,12 @@ html_dependency_magnific_popup <- function() {
                             stylesheet="magnific-popup.css")
 }
 
+html_dependency_navigation <- function(){
+  htmltools::htmlDependency(name = "Navigation",
+                            version = "1.0",
+                            src = system.file(package="rmarkdown", "rmd/h/navigation-1.0/"),
+                            script = "tabsets.js")
+}
 
 bootstrap_chunk_hook <- function(x, options){
   class <- options[["bootstrap.class"]] <- options[["bootstrap.class"]] %||% "row"

--- a/inst/rmarkdown/templates/simple/skeleton/js/simple.js
+++ b/inst/rmarkdown/templates/simple/skeleton/js/simple.js
@@ -39,6 +39,9 @@ $(function() {
     });
   });
   
+  /* Rmarkdown's tabbed navigation */
+  window.buildTabsets("toc");
+  
   /* Activate tooltips */
   $('[data-toggle="tooltip"]').tooltip();
 


### PR DESCRIPTION
*Rmardown* now has [support for tabbed navigation](http://rmarkdown.rstudio.com/html_document_format.html#tabbed_sections). That seems like a nice option to have and since *knitrBootstrap* is build on Rmarkdown anyway it is pretty straightforward to make it available here as well.

The only potential downside I see is that this may create a stronger dependency on a particular version of the Rmarkdown package. Since this requires the location of the javascript file in the Rmarkdown package any change to that would necessitate a change in knitrBootstrap. I don't think that is likely to be too arduous but it is one more thing that can break.