### PR TITLE
switch mathjax CDN to cdnjs

### DIFF
--- a/inst/templates/knitr_bootstrap_includes.html
+++ b/inst/templates/knitr_bootstrap_includes.html
@@ -18,6 +18,6 @@ hljs.LANGUAGES.r=function(a){var b="([a-zA-Z]|\\.[a-zA-Z.])[a-zA-Z0-9._]*";retur
 <!-- Manific Popup -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/magnific-popup.js/0.8.9/jquery.magnific-popup.min.js"></script>
 
-<script type="text/javascript"
-  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+<script type="text/javascript" async
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>


### PR DESCRIPTION
cf [https://www.mathjax.org/cdn-shutting-down/](https://www.mathjax.org/cdn-shutting-down/)
Note that cdnjs does not provide a way to refer directly to the latest version of a library. Yet, mathjax [documentation](http://docs.mathjax.org/en/latest/start.html) recommend this provider.

NB: I could not render the examples for reasons unrelated to mathjax (notably the xtable example in the all.Rmd does not render correctly). Not sure why?

The sample mathjax examples that I ran are working, and the warning in the javascript console disappeared.